### PR TITLE
fixed athena reports test failures

### DIFF
--- a/cypress/integration/tests/athena_reports_testing.spec.js
+++ b/cypress/integration/tests/athena_reports_testing.spec.js
@@ -20,6 +20,9 @@ context("Verify Athena Reports in Staging", () => {
             AthenaReportsHelper.addFiltersInUI(learnersReportPageElements.SELECT_TEACHERS, inputData.teachers);
             AthenaReportsHelper.addFiltersInUI(learnersReportPageElements.SELECT_RUNNABLES, inputData.runnables);
             AthenaReportsHelper.addFiltersInUI(learnersReportPageElements.SELECT_PERMISSION_FORMS, inputData.permissionForms);
+            if(inputData.start_date && inputData.end_date){
+                AthenaReportsHelper.addDateFilter(inputData.start_date, inputData.end_date);
+            }
             AthenaReportsHelper.verifyCountersInUI(outputData);
 
             let queryUrl = null;

--- a/cypress/support/helpers/athenaReportHelper.js
+++ b/cypress/support/helpers/athenaReportHelper.js
@@ -27,6 +27,12 @@ export function addFiltersInUI(uiSelectElement, items){
     });
 }
 
+export function addDateFilter(startDate, endDate){
+    cy.get(learnersReportPageElements.START_DATE).type(startDate, {force: true});
+    cy.get(learnersReportPageElements.END_DATE).type(endDate, {force: true});
+    cy.get(learnersReportPageElements.LBL_LEARNERS_COUNT).click({force: true});
+}
+
 export function verifyCountersInUI(counters){
     cy.get(learnersReportPageElements.LBL_LEARNERS_COUNT).should('have.text', counters.learnersCount);
     cy.get(learnersReportPageElements.LBL_STUDENTS_COUNT).should('have.text', counters.studentsCount);

--- a/cypress/support/testdata/testdata_athena_reports.js
+++ b/cypress/support/testdata/testdata_athena_reports.js
@@ -42,6 +42,8 @@ export const athenaReportsTestDataStaging = [
         testName: 'Multiple Teachers',
         input: {
             teachers: ['Tejal Admin', 'srivardhan sunkesula'],
+            start_date: '04/01/2021',
+            end_date: '08/31/2021',
 
             usageReportExpectedOutput: 'cypress/fixtures/recordings/ur-t_tejaladmin_srivardhansunkesula.csv',
             detailedReportExpectedOutput: 'cypress/fixtures/recordings/dr-t_tejaladmin_srivardhansunkesula.csv',
@@ -49,9 +51,9 @@ export const athenaReportsTestDataStaging = [
         output: {
             learnersCount: 89,
             studentsCount: 18,
-            classesCount: 21,
+            classesCount: 22,
             teachersCount: 2,
-            runnableCount: 34,
+            runnableCount: 32,
         }
     },
     {


### PR DESCRIPTION
Athena reports tests are failing as the activities in tests do not have time bound.
As we run these activities the numbers keep changing and the tests are failing.
As part of this fix, adding start time and end time for the activities so that future activity runs should not impact these tests.