### PR TITLE
PT #187863588: Various improvements to the PermissionsUI automation

### DIFF
--- a/cypress/e2e/functional/researcher_permission_forms.spec.js
+++ b/cypress/e2e/functional/researcher_permission_forms.spec.js
@@ -1,19 +1,16 @@
 import * as c from '../../support/constants.js'
 import {ResearcherPermissionFormsElements as pf} from "../../support/elements/researcher_permission_forms_elements";
 
-const TEST_PROJECT_NAME = 'Test Project',
+const TEST_PROJECT_NAME = 'Cypress Test Project',
+    OTHER_TEST_PROJECT_NAME = 'Test Project',
     TEST_PERMISSION_FORM_NAME = 'PermForm4CypressTests',
-    TEST_PERMISSION_FORM_URL  = 'concord.org'
-    // TODO: I don't know the password for c.RESEARCHER_USERNAME (i.e. 'researcher'), so I've created my own, for now
-    , RESEARCHER_USERNAME = 'atestresearcherforcypresstesting'
-;
+    TEST_PERMISSION_FORM_URL  = 'concord.org';
 
 context("Researcher uses permission forms", () => {
 
     before(function() {
         cy.visit(c.LEARN_PORTAL_BASE_URL); // Visit LEARN Portal home page
-        // cy.login(c.RESEARCHER_USERNAME, c.RESEARCHER_PASSWORD); // Login as researcher user
-        cy.login(RESEARCHER_USERNAME, c.RESEARCHER_PASSWORD); // Login as researcher user
+        cy.login(c.RESEARCHER_USERNAME, c.RESEARCHER_PASSWORD); // Login as user 'researcher'
     });
     
     after(function() {
@@ -30,9 +27,7 @@ context("Researcher uses permission forms", () => {
         pf.clickPermissionFormsLink();
 
         cy.log('Verify that both links exist; but only the Create / Manage Project Permission Forms link is enabled');
-        pf.verifyManageStudentPermissionsLink();
         pf.verifyManageStudentPermissionsLinkEnabled(false);
-        pf.verifyCreateManageProjectPermissionFormsLink();
         pf.verifyCreateManageProjectPermissionFormsLinkEnabled();
 
         cy.log('Click the Create / Manage Project Permission Forms link; then verify that only the Manage Student Permissions link is enabled');
@@ -41,57 +36,83 @@ context("Researcher uses permission forms", () => {
         pf.verifyCreateManageProjectPermissionFormsLinkEnabled(false);
 
         cy.log('Click the Create New Permission Form button, fill in values in the dialog; but then click Cancel');
-        pf.createNewPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME, 'google.com', true);
+        pf.createNewPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'0', 'google.com', null, true);
 
         cy.log('Fill in the Create New Permission Form dialog again, but this time, click the Save button');
         pf.createNewPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'1', TEST_PERMISSION_FORM_URL,
-            false, TEST_PROJECT_NAME);
+            TEST_PROJECT_NAME);
 
+        cy.log('Confirm that the expected Project name is selected');
+        pf.verifyCreateEditPermissionFormProjectName(TEST_PROJECT_NAME);
+    
         cy.log('Create more Permission Forms, to be used to test the Archive, Unarchive & Delete buttons');
         pf.createNewPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'2', 'www.'+TEST_PERMISSION_FORM_URL,
-            false, TEST_PROJECT_NAME);
+            TEST_PROJECT_NAME);
         pf.createNewPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'3', 'learn.'+TEST_PERMISSION_FORM_URL,
-            false, TEST_PROJECT_NAME);
+            TEST_PROJECT_NAME);
+
+        cy.log('Create still more Permission Forms, to be used to test the Manage Student Permissions tab');
         pf.createNewPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'4', 'learn.portal.staging.'+TEST_PERMISSION_FORM_URL,
-            false, TEST_PROJECT_NAME);
+            TEST_PROJECT_NAME);
+        pf.createNewPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'5', 'www.'+TEST_PERMISSION_FORM_URL,
+            TEST_PROJECT_NAME);
+    
+        cy.log('Confirm that the expected Project name is still selected');
+        pf.verifyCreateEditPermissionFormProjectName(TEST_PROJECT_NAME);
 
-        // TODO: Replace this unnecessary line(s) with a check that the Project name displayed is the one that we expect
-        // cy.log("Select a Project from the dropdown (on the 'Create New Permission Form' tab)");
-        // pf.selectCreateManagePermissionsProject(TEST_PROJECT_NAME);
-
-        cy.log('Test the links on the Permission Forms table, starting with URL text, Archive, and Unarchive');
+        cy.log('Test the links on the Permission Forms table, starting with the URL text, ARCHIVE, and UNARCHIVE');
         pf.verifyPermissionFormUrlText(TEST_PERMISSION_FORM_NAME+'1', TEST_PERMISSION_FORM_URL);
         pf.verifyPermissionFormUrlText(TEST_PERMISSION_FORM_NAME+'2', 'www.'+TEST_PERMISSION_FORM_URL);
         pf.verifyPermissionFormUrlText(TEST_PERMISSION_FORM_NAME+'3', 'learn.'+TEST_PERMISSION_FORM_URL);
 
-        // TODO: fix clicking on archived rows, then uncomment these:
-        // pf.clickPermissionFormArchive(TEST_PERMISSION_FORM_NAME+'2');
-        // pf.clickPermissionFormArchive(TEST_PERMISSION_FORM_NAME+'3');
-        // pf.clickPermissionFormUnarchive(TEST_PERMISSION_FORM_NAME+'3');
+        pf.clickPermissionFormArchive(TEST_PERMISSION_FORM_NAME+'2');
+        pf.clickPermissionFormArchive(TEST_PERMISSION_FORM_NAME+'3');
+        pf.clickPermissionFormUnarchive(TEST_PERMISSION_FORM_NAME+'3');
 
         pf.verifyPermissionFormUrlText(TEST_PERMISSION_FORM_NAME+'2', 'www.'+TEST_PERMISSION_FORM_URL);
         pf.verifyPermissionFormUrlText(TEST_PERMISSION_FORM_NAME+'3', 'learn.'+TEST_PERMISSION_FORM_URL);
         pf.verifyPermissionFormUrlText(TEST_PERMISSION_FORM_NAME+'1', TEST_PERMISSION_FORM_URL);
 
-        cy.log('Test the Edit link, for an Archived, an Unarchived and a never-Archived Permision Form');
-        pf.clickPermissionFormEdit(TEST_PERMISSION_FORM_NAME+'2');
-        pf.verifyEditPermissionFormDialog(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'2', 'www.'+TEST_PERMISSION_FORM_URL);
-        pf.clickCreateEditPermissionFormCancelButton();
+        cy.log('Confirm the expected Permission Form names are present');
+        pf.verifyPermissionFormName(TEST_PERMISSION_FORM_NAME+'1');
+        pf.verifyPermissionFormName(TEST_PERMISSION_FORM_NAME+'2');
+        pf.verifyPermissionFormName(TEST_PERMISSION_FORM_NAME+'3');
+        pf.verifyPermissionFormName(TEST_PERMISSION_FORM_NAME+'4');
+        pf.verifyPermissionFormName(TEST_PERMISSION_FORM_NAME+'5');
 
-        pf.clickPermissionFormEdit(TEST_PERMISSION_FORM_NAME+'3');
-        pf.verifyEditPermissionFormDialog(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'3', 'learn.'+TEST_PERMISSION_FORM_URL);
-        pf.clickCreateEditPermissionFormCancelButton();
+        cy.log('Test the Edit link & dialog, for a never-Archived, an Archived, and an Unarchived Permision Form; but click Cancel');
+        pf.editPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'1', TEST_PERMISSION_FORM_URL,
+            OTHER_TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'1_cancel_changes', 'cancel_changes.'+TEST_PERMISSION_FORM_URL, true);
+        pf.editPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'2', 'www.'+TEST_PERMISSION_FORM_URL,
+            OTHER_TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'2_cancel_changes', 'cancel_changes.'+TEST_PERMISSION_FORM_URL, true);
+        pf.editPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'3', 'learn.'+TEST_PERMISSION_FORM_URL,
+            OTHER_TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'3_cancel_changes', 'cancel_changes.'+TEST_PERMISSION_FORM_URL, true);
+        
+        cy.log('Test the Edit link & dialog, for a never-Archived, an Archived, and an Unarchived Permision Form; this time, Save Changes');
+        pf.selectCreateManagePermissionsProject();
+        pf.editPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'1', TEST_PERMISSION_FORM_URL,
+            null, TEST_PERMISSION_FORM_NAME+'1_modified', 'modified.'+TEST_PERMISSION_FORM_URL);
+        pf.editPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'2', 'www.'+TEST_PERMISSION_FORM_URL,
+            OTHER_TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'2_modified', 'modified.'+TEST_PERMISSION_FORM_URL);
+        pf.selectCreateManagePermissionsProject(TEST_PROJECT_NAME);
+        pf.editPermissionForm(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'3', 'learn.'+TEST_PERMISSION_FORM_URL,
+            OTHER_TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'3_modified', 'modified.'+TEST_PERMISSION_FORM_URL);
 
-        pf.clickPermissionFormEdit(TEST_PERMISSION_FORM_NAME+'1');
-        pf.verifyEditPermissionFormDialog(TEST_PROJECT_NAME, TEST_PERMISSION_FORM_NAME+'1', TEST_PERMISSION_FORM_URL);
-        pf.clickCreateEditPermissionFormCancelButton();
+        // TODO: Count the number of Permission Forms, before Deleting them
+        // cy.log('Count the number of Permission Forms, before Deleting them');
+        // pf.selectCreateManagePermissionsProject();
+        // let numPermForm1 = pf.getNumPermissionFormsWithName(TEST_PERMISSION_FORM_NAME+'1_modified');
+        // cy.log('Num forms w. name '+TEST_PERMISSION_FORM_NAME+'1_modified: '+numPermForm1);
 
-        // TODO: add more testing of the Edit Permission Form Dialog (without clicking the 'Cancel' button)
+        cy.log('Test the Delete link, for a never-Archived, an Archived, and an Unarchived Permision Form');
+        pf.selectCreateManagePermissionsProject(TEST_PROJECT_NAME);
+        pf.clickPermissionFormDelete(TEST_PERMISSION_FORM_NAME+'1_modified');
+        pf.selectCreateManagePermissionsProject(OTHER_TEST_PROJECT_NAME);
+        pf.clickPermissionFormDelete(TEST_PERMISSION_FORM_NAME+'2_modified');
+        pf.clickPermissionFormDelete(TEST_PERMISSION_FORM_NAME+'3_modified');
 
-        cy.log('Test the Delete link, for an Archived, an Unarchived and a never-Archived Permision Form');
-        pf.clickPermissionFormDelete(TEST_PERMISSION_FORM_NAME+'2');
-        pf.clickPermissionFormDelete(TEST_PERMISSION_FORM_NAME+'3');
-        pf.clickPermissionFormDelete(TEST_PERMISSION_FORM_NAME+'4');
+        // TODO: Confirm deletion, by counting the number again & comparing
+        // cy.log('Confirm that the Permission Forms were deleted');
 
         cy.log('Move to the Manage Student Permissions tab, checking the Enabled & Disabled links before and after');
         pf.verifyManageStudentPermissionsLinkEnabled();
@@ -100,14 +121,25 @@ context("Researcher uses permission forms", () => {
         pf.verifyManageStudentPermissionsLinkEnabled(false);
         pf.verifyCreateManageProjectPermissionFormsLinkEnabled();
 
-        // TODO: add tests of the Manage Student Permissions tab (see PT story #187863588)
-        cy.log('Test the Manage Student Permissions tab');
+        cy.log('Test the Manage Student Permissions tab ...');
+        cy.log('Select the Project Name');
+        pf.selectManageStudentPermissionsProject(TEST_PROJECT_NAME);
 
-        cy.log('Delete the remaining Permission Form(s) created by this test');
+        // TODO: Test the Manage Student Permissions tab more
+
+        cy.log('Verify that both links still exist; but only the Create / Manage Project Permission Forms link is enabled');
+        pf.verifyManageStudentPermissionsLinkEnabled(false);
+        pf.verifyCreateManageProjectPermissionFormsLinkEnabled();
+
+        cy.log('Click the Create / Manage Project Permission Forms link (again); then verify that only the Manage Student Permissions link is enabled');
         pf.clickCreateManageProjectPermissionFormsLink();
-        pf.clickPermissionFormDelete(TEST_PERMISSION_FORM_NAME+'1');
+        pf.verifyManageStudentPermissionsLinkEnabled();
+        pf.verifyCreateManageProjectPermissionFormsLinkEnabled(false);
 
-
-
+        cy.log('Delete the remaining Permission Form(s) created by this test; and confirm deletion');
+        pf.selectCreateManagePermissionsProject();
+        pf.clickPermissionFormDelete(TEST_PERMISSION_FORM_NAME+'4');
+        pf.clickPermissionFormDelete(TEST_PERMISSION_FORM_NAME+'5');
+        // TODO: Confirm deletion
     });
 });

--- a/cypress/support/elements/researcher_permission_forms_elements.js
+++ b/cypress/support/elements/researcher_permission_forms_elements.js
@@ -111,15 +111,8 @@ export const ResearcherPermissionFormsElements = {
         cy.get(pfe.CREATE_NEW_PERMISSION_FORM_BUTTON).click();
     },
 
-    // On the 'Create New Permission Form' dialog ...
-    verifyCreateNewPermissionFormDialog(project='Select a project...', name='', url='') {
-        this.verifyElementIsPresent(pfe.CREATE_EDIT_PERMISSION_FORM_DIALOG, 'Create New Permission Form');
-        this.verifyElementIsVisible(pfe.CREATE_EDIT_PERM_SELECT_PROJECT_DD, project);
-        this.verifyElementWithValueIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_NAME, name);
-        this.verifyElementWithValueIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_URL,  url);
-        this.verifyElementIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_CANCEL, 'Cancel');
-        this.verifyElementIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_SAVE,   'Save');
-    },
+    // On the 'Create New Permission Form' dialog; or the nearly identical
+    // 'EDIT: <Permission Form name>' dialog ...
     verifyCreateEditPermissionFormSaveButtonEnabled(enabled=true) {
         if (enabled) {
             cy.get(pfe.CREATE_EDIT_PERMISSION_FORM_SAVE).should('not.have.attr', 'disabled');
@@ -162,6 +155,35 @@ export const ResearcherPermissionFormsElements = {
         cy.get(pfe.CREATE_EDIT_PERM_FORM_SAVE_CHANGES).click();
     },
 
+
+    // A utility method used by both of the methods below
+    verifyCreateEditPermissionFormDialog(project='', name='', url='',
+            formHeaderText='Create New Permission Form', SaveButtonText='Save') {
+        this.verifyElementIsPresent(pfe.CREATE_EDIT_PERMISSION_FORM_DIALOG, formHeaderText);
+        this.verifyElementIsVisible(pfe.CREATE_EDIT_PERM_SELECT_PROJECT_DD, project);
+        this.verifyElementWithValueIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_NAME, name);
+        this.verifyElementWithValueIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_URL,  url);
+        this.verifyElementIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_CANCEL, 'Cancel');
+        this.verifyElementIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_SAVE,   SaveButtonText);
+    },
+
+    // Confirm that the 'Create New Permission Form' shows the expected values
+    // - very similar to verifyEditPermissionFormDialog() above
+    verifyCreateNewPermissionFormDialog(project='Select a project...', name='', url='') {
+        this.verifyCreateEditPermissionFormDialog(project, name, url);
+    },
+
+    // Confirm that the 'EDIT: <Permission Form name>' shows the expected values
+    // - very similar to verifyCreateNewPermissionFormDialog() above
+    verifyEditPermissionFormDialog(project='', name='', url='', oldName=null) {
+        let formHeaderText = 'EDIT: '+name;
+        if (oldName != null) {
+            formHeaderText = 'EDIT: '+oldName;
+        }
+        this.verifyCreateEditPermissionFormDialog(project, name, url, formHeaderText, 'Save Changes');
+    },
+
+
     // A method that creates a new Permission Form, using most of the methods above
     createNewPermissionForm(project, name, url='', current_project=null, cancel=false) {
         if (current_project == null) {
@@ -175,26 +197,12 @@ export const ResearcherPermissionFormsElements = {
         this.enterCreateEditPermissionFormName(name);
         this.verifyCreateEditPermissionFormSaveButtonEnabled();
         this.enterCreateEditPermissionFormUrl(url);
+        this.verifyCreateNewPermissionFormDialog(current_project, name, url);
         if (cancel) {
             this.clickCreateEditPermissionFormCancelButton();
         } else {
             this.clickCreatePermissionFormSaveButton();
         }
-    },
-
-
-    // On the 'EDIT: <Permission Form name>' dialog (almost identical to the 'Create New Permission Form' dialog)
-    verifyEditPermissionFormDialog(project='', name='', url='', oldName=null) {
-        if (oldName == null) {
-            this.verifyElementIsPresent(pfe.CREATE_EDIT_PERMISSION_FORM_DIALOG, 'EDIT: '+name);
-        } else {
-            this.verifyElementIsPresent(pfe.CREATE_EDIT_PERMISSION_FORM_DIALOG, 'EDIT: '+oldName);
-        }
-        this.verifyElementIsVisible(pfe.CREATE_EDIT_PERM_SELECT_PROJECT_DD, project);
-        this.verifyElementWithValueIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_NAME, name);
-        this.verifyElementWithValueIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_URL,  url);
-        this.verifyElementIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_CANCEL, 'Cancel');
-        this.verifyElementIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_SAVE,   'Save Changes');
     },
 
     // A method that edits an existing Permission Form, using methods above,

--- a/cypress/support/elements/researcher_permission_forms_elements.js
+++ b/cypress/support/elements/researcher_permission_forms_elements.js
@@ -1,27 +1,33 @@
 import * as ape from '../../support/elements/admin_page_elements.js'
 
 // Used multiple times in the 'pfe' constants defined below
-const CREATE_EDIT_PERMISSION_FORM = 'div[class="createEditPermissionForm--pmsqnW6J"]'
+const CREATE_EDIT_PERMISSION_FORM = 'div[class^="createEditPermissionForm"]'
 
 const pfe = {  // permission forms elements
-    PERMISSION_FORMS_LINK: 'li a[href="/admin/permission_forms_v2"]',
+    PERMISSION_FORMS_LINK: 'li a[href="/admin/permission_forms"]',
 
     MANAGE_STUDENT_PERMISSIONS_LINK: 'button:contains("Manage Student Permissions")',
     CREATE_MANAGE_PROJECT_PERMISSION_FORMS_LINK: 'button:contains("Create / Manage Project Permission Forms")',
 
-    MANAGE_STUDENT_PERMISSIONS_SELECT_PROJECT_DROPDOWN: 'div[class="rightSide--uMV6wNuK"] select[data-testid="project-select"]',
-    CREATE_MANAGE_PROJECT_PERMISSION_SELECT_PROJECT_DD: 'div[class="leftSide--T1Ykz03v"]  select[data-testid="project-select"]',
+    MANAGE_STUDENT_PERMISSIONS_SELECT_PROJECT_DROPDOWN: 'div[class^="studentsTabContent"]    select[data-testid="project-select"]',
+    CREATE_MANAGE_PROJECT_PERMISSION_SELECT_PROJECT_DD: 'div[class^="manageFormsTabContent"] select[data-testid="project-select"]',
 
     CREATE_NEW_PERMISSION_FORM_BUTTON: 'button:contains("Create New Permission Form")',
     CREATE_EDIT_PERMISSION_FORM_DIALOG: CREATE_EDIT_PERMISSION_FORM,
     CREATE_EDIT_PERM_SELECT_PROJECT_DD: CREATE_EDIT_PERMISSION_FORM+' select[data-testid="project-select"]',
-    CREATE_EDIT_PERMISSION_FORM_NAME:   CREATE_EDIT_PERMISSION_FORM+' input[class="name--U_hCA8iT"]',
-    CREATE_EDIT_PERMISSION_FORM_URL:    CREATE_EDIT_PERMISSION_FORM+' input[class="url--raKu4IoT"]',
-    CREATE_EDIT_PERMISSION_FORM_CANCEL: CREATE_EDIT_PERMISSION_FORM+' button[class="cancelButton--dk30CMiV"]',
+    CREATE_EDIT_PERMISSION_FORM_NAME:   CREATE_EDIT_PERMISSION_FORM+' input[class^="name"]',
+    CREATE_EDIT_PERMISSION_FORM_URL:    CREATE_EDIT_PERMISSION_FORM+' input[class^="url"]',
+    CREATE_EDIT_PERMISSION_FORM_CANCEL: CREATE_EDIT_PERMISSION_FORM+' button[class^="cancelButton"]',
     CREATE_EDIT_PERMISSION_FORM_SAVE:   CREATE_EDIT_PERMISSION_FORM+' button:contains("Save")',
+    CREATE_EDIT_PERM_FORM_SAVE_CHANGES: CREATE_EDIT_PERMISSION_FORM+' button:contains("Save Changes")',
 
-    PERMISSION_FORMS_TABLE_ROW:          'div[class="manageFormsTabContent--PW4_5pMp"] table tbody tr[class="permissionFormRow--BC9FzE66"]',
-    ARCHIVED_PERMISSION_FORMS_TABLE_ROW: 'table tbody tr[class="isArchived--H3taEbTW"]',
+    PERMISSION_FORMS_TABLE:             'div[class^="manageFormsTabContent"] table tbody',
+    PERMISSION_FORMS_ROW:               'tr[class^="permissionFormRow"] td',
+    PERMISSION_FORMS_TABLE_ROW:         'div[class^="manageFormsTabContent"] table tbody tr[class^="permissionFormRow"]',
+
+    MANAGE_STUDENT_PERM_TEACHER_INPUT:  'div[class^="studentsTabContent"] input[type="text"]',
+    MANAGE_STUDENT_PERM_SEARCH_BUTTON:  'div[class^="studentsTabContent"] button:contains("Search")',
+
 };
   
 export const ResearcherPermissionFormsElements = {
@@ -53,15 +59,14 @@ export const ResearcherPermissionFormsElements = {
         cy.get(pfe.PERMISSION_FORMS_LINK).click();
     },
 
+
     // Link to the 'Manage Student Permissions' tab (of the Permission Forms page)
-    verifyManageStudentPermissionsLink() {
-        this.verifyElementIsVisible(pfe.MANAGE_STUDENT_PERMISSIONS_LINK, 'Manage Student Permissions');
-    },
     verifyManageStudentPermissionsLinkEnabled(enabled=true) {
+        this.verifyElementIsVisible(pfe.MANAGE_STUDENT_PERMISSIONS_LINK, 'Manage Student Permissions');
         if (enabled) {
-            cy.get(pfe.MANAGE_STUDENT_PERMISSIONS_LINK).should('not.have.class', 'disabled--KTkcqshd');
+            cy.get(pfe.MANAGE_STUDENT_PERMISSIONS_LINK).invoke('attr', 'class').should('not.contain', 'disabled');
         } else {
-            cy.get(pfe.MANAGE_STUDENT_PERMISSIONS_LINK).should('have.class', 'disabled--KTkcqshd');
+            cy.get(pfe.MANAGE_STUDENT_PERMISSIONS_LINK).invoke('attr', 'class').should('contain', 'disabled');
         }
     },
     clickManageStudentPermissionsLink() {
@@ -69,14 +74,12 @@ export const ResearcherPermissionFormsElements = {
     },
 
     // Link to the 'Create New Permission Form' tab (of the Permission Forms page)
-    verifyCreateManageProjectPermissionFormsLink() {
-        this.verifyElementIsVisible(pfe.CREATE_MANAGE_PROJECT_PERMISSION_FORMS_LINK, 'Create / Manage Project Permission Forms');
-    },
     verifyCreateManageProjectPermissionFormsLinkEnabled(enabled=true) {
+        this.verifyElementIsVisible(pfe.CREATE_MANAGE_PROJECT_PERMISSION_FORMS_LINK, 'Create / Manage Project Permission Forms');
         if (enabled) {
-            cy.get(pfe.CREATE_MANAGE_PROJECT_PERMISSION_FORMS_LINK).should('not.have.class', 'disabled--KTkcqshd');
+            cy.get(pfe.CREATE_MANAGE_PROJECT_PERMISSION_FORMS_LINK).invoke('attr', 'class').should('not.contain', 'disabled');
         } else {
-            cy.get(pfe.CREATE_MANAGE_PROJECT_PERMISSION_FORMS_LINK).should('have.class', 'disabled--KTkcqshd');
+            cy.get(pfe.CREATE_MANAGE_PROJECT_PERMISSION_FORMS_LINK).invoke('attr', 'class').should('contain', 'disabled');
         }
     },
     clickCreateManageProjectPermissionFormsLink() {
@@ -87,17 +90,18 @@ export const ResearcherPermissionFormsElements = {
     verifyCreateManagePermissionsSelectProjectDropdown(project='Select a project...') {
         this.verifyElementIsVisible(pfe.CREATE_MANAGE_PROJECT_PERMISSION_SELECT_PROJECT_DD, project);
     },
-    selectCreateManagePermissionsProject(project) {
-        cy.get(pfe.CREATE_MANAGE_PROJECT_PERMISSION_SELECT_PROJECT_DD).select(project);
+    selectCreateManagePermissionsProject(project='Select a project...') {
+        cy.get(pfe.CREATE_MANAGE_PROJECT_PERMISSION_SELECT_PROJECT_DD).first().select(project);
     },
 
     // ... and on the 'Manage Student Permissions' tab
     verifyManageStudentPermissionsSelectProjectDropdown(project='Select a project...') {
         this.verifyElementIsVisible(pfe.MANAGE_STUDENT_PERMISSIONS_SELECT_PROJECT_DROPDOWN, project);
     },
-    selectManageStudentPermissionsProject(project) {
+    selectManageStudentPermissionsProject(project='Select a project...') {
         cy.get(pfe.MANAGE_STUDENT_PERMISSIONS_SELECT_PROJECT_DROPDOWN).select(project);
     },
+
 
     // The button that brings up the 'Create New Permission Form' dialog
     verifyCreateNewPermissionFormButton() {
@@ -107,7 +111,7 @@ export const ResearcherPermissionFormsElements = {
         cy.get(pfe.CREATE_NEW_PERMISSION_FORM_BUTTON).click();
     },
 
-    // On the 'Create New Permission Form' dialog
+    // On the 'Create New Permission Form' dialog ...
     verifyCreateNewPermissionFormDialog(project='Select a project...', name='', url='') {
         this.verifyElementIsPresent(pfe.CREATE_EDIT_PERMISSION_FORM_DIALOG, 'Create New Permission Form');
         this.verifyElementIsVisible(pfe.CREATE_EDIT_PERM_SELECT_PROJECT_DD, project);
@@ -123,28 +127,46 @@ export const ResearcherPermissionFormsElements = {
             cy.get(pfe.CREATE_EDIT_PERMISSION_FORM_SAVE).should('have.attr', 'disabled');
         }
     },
-    selectCreateEditPermissionFormProject(project) {
-        cy.get(pfe.CREATE_EDIT_PERM_SELECT_PROJECT_DD).select(project);
+    selectCreateEditPermissionFormProject(projectName='Select a project...') {
+        cy.get(pfe.CREATE_EDIT_PERM_SELECT_PROJECT_DD).select(projectName);
+    },
+    getCreateEditPermissionFormProjectName() {
+        return cy.get(pfe.CREATE_EDIT_PERM_SELECT_PROJECT_DD+' option:selected').invoke('text');
+    },
+    verifyCreateEditPermissionFormProjectName(projectName) {
+        this.getCreateEditPermissionFormProjectName().should('equal', projectName);
     },
     enterCreateEditPermissionFormName(name) {
         if (name != null && name != '') {
+            cy.get(pfe.CREATE_EDIT_PERMISSION_FORM_NAME).clear();            
             cy.get(pfe.CREATE_EDIT_PERMISSION_FORM_NAME).type(name);            
         }
     },
     enterCreateEditPermissionFormUrl(url) {
         if (url != null && url != '') {
+            cy.get(pfe.CREATE_EDIT_PERMISSION_FORM_URL).clear();            
             cy.get(pfe.CREATE_EDIT_PERMISSION_FORM_URL).type(url);            
         }
     },
     clickCreateEditPermissionFormCancelButton() {
         cy.get(pfe.CREATE_EDIT_PERMISSION_FORM_CANCEL).click();
     },
-    clickCreateEditPermissionFormSaveButton() {
+
+    // The 'Create New Permission Form' and 'EDIT Permission Form' dialogs are mostly the same,
+    // so the above methods can be used for either one; but the former has a 'Save' button and
+    // the latter a 'Save Changes' button, so these methods are slightly different
+    clickCreatePermissionFormSaveButton() {
         cy.get(pfe.CREATE_EDIT_PERMISSION_FORM_SAVE).click();
     },
+    clickEditPermissionFormSaveChangesButton() {
+        cy.get(pfe.CREATE_EDIT_PERM_FORM_SAVE_CHANGES).click();
+    },
 
-    // A method that does most of the above, consecutively
-    createNewPermissionForm(project, name, url='', cancel=false, current_project='Select a project...') {
+    // A method that creates a new Permission Form, using most of the methods above
+    createNewPermissionForm(project, name, url='', current_project=null, cancel=false) {
+        if (current_project == null) {
+            current_project='Select a project...'
+        }
         this.verifyCreateNewPermissionFormButton();
         this.clickCreateNewPermissionFormButton();
         this.verifyCreateNewPermissionFormDialog(current_project);
@@ -156,13 +178,18 @@ export const ResearcherPermissionFormsElements = {
         if (cancel) {
             this.clickCreateEditPermissionFormCancelButton();
         } else {
-            this.clickCreateEditPermissionFormSaveButton();
+            this.clickCreatePermissionFormSaveButton();
         }
     },
 
-    // On the 'Edit: <Permission Form name>' dialog (almost identical to the 'Create New Permission Form' dialog)
-    verifyEditPermissionFormDialog(project='', name='', url='') {
-        this.verifyElementIsPresent(pfe.CREATE_EDIT_PERMISSION_FORM_DIALOG, 'EDIT: '+name);
+
+    // On the 'EDIT: <Permission Form name>' dialog (almost identical to the 'Create New Permission Form' dialog)
+    verifyEditPermissionFormDialog(project='', name='', url='', oldName=null) {
+        if (oldName == null) {
+            this.verifyElementIsPresent(pfe.CREATE_EDIT_PERMISSION_FORM_DIALOG, 'EDIT: '+name);
+        } else {
+            this.verifyElementIsPresent(pfe.CREATE_EDIT_PERMISSION_FORM_DIALOG, 'EDIT: '+oldName);
+        }
         this.verifyElementIsVisible(pfe.CREATE_EDIT_PERM_SELECT_PROJECT_DD, project);
         this.verifyElementWithValueIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_NAME, name);
         this.verifyElementWithValueIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_URL,  url);
@@ -170,66 +197,111 @@ export const ResearcherPermissionFormsElements = {
         this.verifyElementIsVisible(pfe.CREATE_EDIT_PERMISSION_FORM_SAVE,   'Save Changes');
     },
 
+    // A method that edits an existing Permission Form, using methods above,
+    // as createNewPermissionForm() does for a new Permission Form
+    editPermissionForm(oldProjectName, oldPermFormName, oldUrl,
+            newProjectName=null, newPerfFormName=null, newUrl=null, cancel=false) {
+        this.clickPermissionFormEdit(oldPermFormName)
+        this.verifyEditPermissionFormDialog(oldProjectName, oldPermFormName, oldUrl)
+
+        let currentProjectName  = oldProjectName;
+        let currentPermFormName = oldPermFormName;
+        let currentUrl          = oldUrl;
+        if (newProjectName != null && newProjectName != '') {
+            this.selectCreateEditPermissionFormProject(newProjectName);
+            currentProjectName = newProjectName;
+        }
+        if (newPerfFormName != null && newPerfFormName != '') {
+            this.enterCreateEditPermissionFormName(newPerfFormName);
+            currentPermFormName = newPerfFormName;
+        }
+        // the "URL" can be blank, unlike the others above, so a value of '' is allowed
+        if (newUrl != null) {
+            this.enterCreateEditPermissionFormUrl(newUrl);
+            currentUrl = newUrl;
+        }
+        this.verifyEditPermissionFormDialog(currentProjectName, currentPermFormName, currentUrl, oldPermFormName);
+
+        if (cancel) {
+            this.clickCreateEditPermissionFormCancelButton();
+        } else {
+            this.clickEditPermissionFormSaveChangesButton();
+        }
+    },
+
+
     // Utility methods, used by the methods below
-    getSpecifiedRowLink(tableRowIdentifier, permissionFormName, linkClass, expectedText, tag='button') {
-        return cy.get(tableRowIdentifier+':contains("'+permissionFormName+'") '+
-            'td[class="'+linkClass+'"] '+tag+':contains("'+expectedText+'")').first();
+    getPermissionFormLinks(permissionFormName, linkClass, expectedText, tag='button', archived=false) {
+        return cy.get(pfe.PERMISSION_FORMS_TABLE_ROW+':contains("'+permissionFormName+'") td[class^="'+linkClass+'"] '
+            +tag+':contains("'+expectedText+'")');
     },
     getPermissionFormLink(permissionFormName, linkClass, expectedText, tag='button', archived=false) {
-        // if (archived) {
-        //     return this.getSpecifiedRowLink(pfe.ARCHIVED_PERMISSION_FORMS_TABLE_ROW,
-        //         permissionFormName, linkClass, expectedText, tag);
-        // } else {
-            // return this.getSpecifiedRowLink(pfe.PERMISSION_FORMS_TABLE_ROW,
-            //     permissionFormName, linkClass, expectedText, tag);
-        // }
-        return cy.get(pfe.PERMISSION_FORMS_TABLE_ROW+':contains("'+permissionFormName+'") td[class="'+linkClass+'"] '+tag+':contains("'+expectedText+'")');
+        return this.getPermissionFormLinks(permissionFormName, linkClass, expectedText, tag).first();
     },
     clickPermissionFormLink(permissionFormName, linkClass, expectedText, tag='button') {
-        // this.getPermissionFormLink(permissionFormName, linkClass, expectedText, tag).first().click();
-
-        // PERMISSION_FORMS_TABLE_ROW:          'div[class="manageFormsTabContent--PW4_5pMp"] table tbody tr[class="permissionFormRow--BC9FzE66"]',
-
-        // cy.get(pfe.PERMISSION_FORMS_TABLE_ROW+':contains("'+permissionFormName+'") td[class="'+linkClass+'"] '+tag+':contains("'+expectedText+'")').first().click();
-
-        cy.get(pfe.PERMISSION_FORMS_TABLE_ROW+' td:contains("'+permissionFormName+'")').first().parent()
-            .find(' td[class="'+linkClass+'"] '+tag
-            // +':contains("'+expectedText+'")'
-        ).click();
+        this.getPermissionFormLink(permissionFormName, linkClass, expectedText, tag).click()
     },
 
     // Click links in a specified row of the Permission Forms table
     clickPermissionFormEdit(permissionFormName) {
-        this.clickPermissionFormLink(permissionFormName, 'editColumn--nW9BjVVG', 'Edit');
-        // cy.wait(2000);
+        this.clickPermissionFormLink(permissionFormName, 'editColumn', 'Edit');
     },
     clickPermissionFormArchive(permissionFormName) {
-        this.clickPermissionFormLink(permissionFormName, 'archiveColumn--vezR01zs', 'Archive');
-        // cy.wait(2000);
+        this.clickPermissionFormLink(permissionFormName, 'archiveColumn', 'Archive');
     },
     clickPermissionFormUnarchive(permissionFormName) {
-        this.clickPermissionFormLink(permissionFormName, 'archiveColumn--vezR01zs', 'Unarchive', 'button', true);
-        // cy.wait(2000);
+        this.clickPermissionFormLink(permissionFormName, 'archiveColumn', 'Unarchive', 'button', true);
     },
     clickPermissionFormDelete(permissionFormName) {
-        this.clickPermissionFormLink(permissionFormName, 'deleteColumn--IzVI9YZC', 'Delete');
-        // cy.wait(2000);
+        this.clickPermissionFormLink(permissionFormName, 'deleteColumn', 'Delete');
     },
-    // TODO: this is currently unused, because it would bring up another tab
+    // TODO: this is currently unused, because it would bring up another tab, which is hard to deal with in Cypress
     clickPermissionFormUrl(permissionFormName) {
-        this.clickPermissionFormLink(permissionFormName, 'urlColumn--z1WHekGk', 'https://', 'a');
-        // cy.wait(2000);
+        this.clickPermissionFormLink(permissionFormName, 'urlColumn', 'https://', 'a');
     },
 
-    // Get / verify the text of a URL link
+    // Get / verify the permission form name and the text of a URL link
+    getPermissionFormName(permissionFormName) {
+        // TODO: fix this (the 'td' is redundant); or remove it if it's not needed
+        return this.getPermissionFormLink(permissionFormName, 'nameColumn', permissionFormName, 'td').invoke('text');
+    },
+    verifyPermissionFormName(permissionFormName) {
+        this.verifyElementIsVisible(pfe.PERMISSION_FORMS_TABLE_ROW+':contains("'
+            +permissionFormName+'") td[class^="nameColumn"]', permissionFormName);
+    },
     getPermissionFormUrlText(permissionFormName) {
-        return this.getPermissionFormLink(permissionFormName, 'urlColumn--z1WHekGk', 'https://', 'a').text();
+        return this.getPermissionFormLink(permissionFormName, 'urlColumn', 'https://', 'a').invoke('text');
     },
     verifyPermissionFormUrlText(permissionFormName, expectedUrlText) {
-        this.getPermissionFormLink(permissionFormName, 'urlColumn--z1WHekGk', 'https://', 'a')
-            .should('contain', expectedUrlText);
+        this.getPermissionFormUrlText(permissionFormName).should('contain', expectedUrlText);
     },
 
 
+    // Get / verify the number of Permission Forms with a specified name
+    getNumPermissionFormsWithName(permissionFormName) {
+        // TODO: get this to work (just returns 'undefined')
+        return cy.get('div[class^="manageFormsTabContent"] table tbody').first()
+                 .get('tr[class^="permissionFormRow"]:contains("'+permissionFormName+'")').length;
+
+        // An earlier attempt (also did not work):
+        // return cy.get(pfe.PERMISSION_FORMS_TABLE).then((table) => {
+        //     table.find(pfe.PERMISSION_FORMS_ROW+':contains("'+permissionFormName+'")');
+        // });
+    },
+    verifyNumPermissionForms(permissionFormName, expectedNumber) {
+        // TODO: get this to work
+        cy.get(pfe.PERMISSION_FORMS_TABLE_ROW+':contains("'+permissionFormName+'")').should('have.length', expectedNumber);
+    },
+
+
+    // On the 'Manage Student Permissions' tab ...
+    enterManageStudentPermTeacherName(teacherName) {
+        if (teacherName != null && teacherName != '') {
+            cy.get(pfe.MANAGE_STUDENT_PERM_TEACHER_INPUT).type(teacherName);            
+        }
+    },
+    clickTeacherSearchButton() {
+        cy.get(pfe.MANAGE_STUDENT_PERM_SEARCH_BUTTON).click();
+    },
 
 }


### PR DESCRIPTION
Changes include:
- Got the tests working with the c.RESEARCHER_USERNAME, c.RESEARCHER_PASSWORD constants, rather than a hard-coded username;
- Fixed clicking on archived rows;
- Added more testing of the Edit Permission Form Dialog (not just clicking the 'Cancel' button);
- After creating a permission form, confirms that the project name is displayed, on the Create/ Manage Project Permission Forms tab.